### PR TITLE
fix #4 - textSize no longer requires px unit

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -30,6 +30,21 @@ export const combineAllStyles = (
     {}
   );
 
+export const convertAttributeValues = (
+  attributes: AttributesList
+): AttributesList => {
+  const convertedAttributes: AttributesList = {};
+  for (const key in attributes) {
+    const value = attributes[key] as string;
+    if (isNaN(parseFloat(value)) === false) {
+      convertedAttributes[key] = parseFloat(value);
+    } else {
+      convertedAttributes[key] = value;
+    }
+  }
+  return convertedAttributes;
+};
+
 /**
  * Replaces properties of a TextStyle object with new values.
  * (Since AttributeLists are basically partially defined styles, this is the same as combineStyles)
@@ -41,7 +56,7 @@ export const injectAttributes = (
   style: TextStyleExtended = {}
 ): TextStyleExtended | undefined => {
   if (isEmptyObject(style) && isEmptyObject(attributes)) return undefined;
-  return combineRecords(style, attributes);
+  return combineRecords(style, convertAttributeValues(attributes));
 };
 
 /**

--- a/test/style.test.ts
+++ b/test/style.test.ts
@@ -37,7 +37,7 @@ describe("style module", () => {
           { fontWeight: "400", fontSize: 12 }
         )
       ).toMatchObject({
-        fontWeight: "700",
+        fontWeight: 700,
         fontSize: 12,
         fill: "#333333",
       });
@@ -60,7 +60,7 @@ describe("style module", () => {
 
       expect(emStyle).toMatchObject({
         fontStyle: "italic",
-        fontWeight: "700",
+        fontWeight: 700,
       });
     });
   });


### PR DESCRIPTION
<img width="192" alt="Screen Shot 2021-03-30 at 18 15 15" src="https://user-images.githubusercontent.com/141928/113076551-235dea00-9184-11eb-8bc4-67600b714333.png">

Also, all style attribute values that are numbers are converted to numbers.